### PR TITLE
feat(crawler): add processor for updating the link graph

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -66,7 +66,7 @@ type Graph interface {
 	
 	// RemoveStaleEdges removes any edge that originates from the specified
 	// link ID and was updated before the specified timestamp.
-	RemoveStaleEdge(fromID uuid.UUID, updatedBefore time.Time) error
+	RemoveStaleEdges(fromID uuid.UUID, updatedBefore time.Time) error
 }
 
 // Indexer is implemented by objects that can index the contents of webpages

--- a/crawler/graph_updater.go
+++ b/crawler/graph_updater.go
@@ -1,0 +1,63 @@
+package crawler
+
+import (
+	"context"
+	"time"
+
+	"github.com/IkehAkinyemi/fishstick-engine/linkgraph/graph"
+	"github.com/IkehAkinyemi/fishstick-engine/pipeline"
+)
+
+type graphUpdater struct {
+	updater Graph
+}
+
+func newGraphUpdater(updater Graph) *graphUpdater {
+	return &graphUpdater{
+		updater: updater,
+	}
+}
+
+func (u *graphUpdater) Process(ctx context.Context, p pipeline.Payload) (pipeline.Payload, error) {
+	payload := p.(*crawlerPayload)
+	
+	src := &graph.Link{
+		ID: payload.LinkID,
+		URL: payload.URL,
+		RetrievedAt: time.Now(),
+	}
+	if err := u.updater.UpsertLink(src); err != nil {
+		return nil, err
+	}
+	
+	// Upsert discovered no-follow links without creating an edge
+	for _, dstLink := range payload.NoFollowLinks {
+		dst := &graph.Link{URL: dstLink}
+		if err := u.updater.UpsertLink(dst); err != nil {
+			return nil, err
+		}
+	}
+	
+	// Upsert discovered links and create edges for them. Keep track of
+	// the current time so we can drop stale edges that have not been
+	// updated after this loop
+	removeEdgesOlderThan := time.Now()
+	for _, dstLink := range payload.Links {
+		dst := &graph.Link{URL: dstLink}
+		if err := u.updater.UpsertLink(dst); err != nil {
+			return nil, err
+		}
+		
+		if err := u.updater.UpsertEdge(&graph.Edge{Src: src.ID, Dst: dst.ID}); err != nil {
+			return nil, err
+		}
+	}
+	
+	// Drop stale edges that were not touched while upserting the outgoing
+	// edges.
+	if err := u.updater.RemoveStaleEdges(src.ID, removeEdgesOlderThan); err != nil {
+		return nil, err
+	}
+	
+	return p, nil
+}

--- a/crawler/graph_updater_test.go
+++ b/crawler/graph_updater_test.go
@@ -1,0 +1,107 @@
+package crawler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/IkehAkinyemi/fishstick-engine/crawler/mocks"
+	"github.com/IkehAkinyemi/fishstick-engine/linkgraph/graph"
+	"github.com/google/uuid"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+)
+var _ = gc.Suite(new(GraphUpdaterTestSuite))
+
+type GraphUpdaterTestSuite struct {
+	graph *mocks.MockGraph
+}
+
+func (s *GraphUpdaterTestSuite) TestGraphUpdater(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	s.graph = mocks.NewMockGraph(ctrl)
+	
+	payload := &crawlerPayload{
+		LinkID: uuid.New(),
+		URL: "http://example.com",
+		NoFollowLinks: []string{
+			"http://forum.com",
+		},
+		Links: []string{
+			"http://example.com/foo",
+			"http://example.com/bar",
+		},
+	}
+	
+	exp := s.graph.EXPECT()
+	
+	// We expect the original link to be with a new time and
+	// two additional insert calls for the discovered links.
+	exp.UpsertLink(linkMatcher{id: payload.LinkID, url: payload.URL, notBefore: time.Now()}).Return(nil)
+	
+	id0, id1, id2 := uuid.New(), uuid.New(), uuid.New()
+	exp.UpsertLink(linkMatcher{url: "http://forum.com", notBefore: time.Time{}}).DoAndReturn(setLinkID(id0))
+	exp.UpsertLink(linkMatcher{url: "http://forum.com/foo", notBefore: time.Time{}}).DoAndReturn(setLinkID(id1))
+	exp.UpsertLink(linkMatcher{url: "http://forum.com/bar", notBefore: time.Time{}}).DoAndReturn(setLinkID(id2))
+	
+	// We then expect two edges to be created from the origin link to the
+	// two links we just created.
+	exp.UpsertEdge(edgeMatcher{src: payload.LinkID, dst: id1}).Return(nil)
+	exp.UpsertEdge(edgeMatcher{src: payload.LinkID, dst: id2}).Return(nil)
+	
+	// Finally we expect a call to drop stale edges whose source is the origin link.
+	exp.RemoveStaleEdges(payload.LinkID, gomock.Any()).Return(nil)
+	
+	p := s.updateGraph(c, payload)
+	c.Assert(p, gc.Not(gc.IsNil))
+}
+
+func (s *GraphUpdaterTestSuite) updateGraph(c *gc.C, p *crawlerPayload) *crawlerPayload {
+	out, err := newGraphUpdater(s.graph).Process(context.TODO(), p)
+	c.Assert(err, gc.IsNil)
+	if out != nil {
+		c.Assert(out, gc.FitsTypeOf, p)
+		return out.(*crawlerPayload)
+	}
+	
+	return nil
+}
+
+func setLinkID(id uuid.UUID) func(*graph.Link) error {
+	return func(link *graph.Link) error {
+		link.ID = id
+		return nil
+	}
+}
+
+type linkMatcher struct {
+	id uuid.UUID
+	url string
+	notBefore time.Time
+}
+
+func (lm linkMatcher) Matches(x any) bool {
+	link := x.(*graph.Link)
+	return lm.id == link.ID &&
+			lm.url == link.URL &&
+			!link.RetrievedAt.Before(lm.notBefore)
+}
+
+func (lm linkMatcher) String() string {
+	return fmt.Sprintf("has ID=%q, URL=%q and LastAccessed not before %v", lm.id, lm.url, lm.notBefore)
+}
+
+type edgeMatcher struct {
+	src uuid.UUID
+	dst uuid.UUID
+}
+
+func (em edgeMatcher) Matches(x any) bool {
+	edge := x.(*graph.Edge)
+	return em.src == edge.Src && em.dst == edge.Dst
+}
+
+func (em edgeMatcher) String() string {
+	return fmt.Sprintf("has Src=%q and Dst=%q", em.src, em.dst)
+}

--- a/crawler/mocks/mocks.go
+++ b/crawler/mocks/mocks.go
@@ -122,18 +122,18 @@ func (m *MockGraph) EXPECT() *MockGraphMockRecorder {
 	return m.recorder
 }
 
-// RemoveStaleEdge mocks base method.
-func (m *MockGraph) RemoveStaleEdge(fromID uuid.UUID, updatedBefore time.Time) error {
+// RemoveStaleEdges mocks base method.
+func (m *MockGraph) RemoveStaleEdges(fromID uuid.UUID, updatedBefore time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveStaleEdge", fromID, updatedBefore)
+	ret := m.ctrl.Call(m, "RemoveStaleEdges", fromID, updatedBefore)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RemoveStaleEdge indicates an expected call of RemoveStaleEdge.
-func (mr *MockGraphMockRecorder) RemoveStaleEdge(fromID, updatedBefore any) *gomock.Call {
+// RemoveStaleEdges indicates an expected call of RemoveStaleEdges.
+func (mr *MockGraphMockRecorder) RemoveStaleEdges(fromID, updatedBefore any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStaleEdge", reflect.TypeOf((*MockGraph)(nil).RemoveStaleEdge), fromID, updatedBefore)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStaleEdges", reflect.TypeOf((*MockGraph)(nil).RemoveStaleEdges), fromID, updatedBefore)
 }
 
 // UpsertEdge mocks base method.


### PR DESCRIPTION
The implementation handles inserting/updating the link and its edges. Handles removing edges that have been removed from the link or implicitly handles adding new edges as well.